### PR TITLE
[fix] g:colors_nameを設定/not 256colorに対し、t_Coの処理を削除

### DIFF
--- a/colors/laserwave.vim
+++ b/colors/laserwave.vim
@@ -9,14 +9,9 @@
 " License:    MIT
 
 
-if !has('gui_running') && &t_Co < 256
-  finish
-endif
-
 hi clear
-if exists('syntax_on')
-  syntax reset
-endif
+if exists('syntax_on') | syntax reset | endif
+let g:colors_name = 'laserwave'
 
 hi Normal ctermbg=NONE ctermfg=NONE
 hi ColorColumn cterm=NONE ctermbg=235 ctermfg=NONE guibg=#262626

--- a/colors/laserwave256.vim
+++ b/colors/laserwave256.vim
@@ -14,9 +14,8 @@ if !has('gui_running') && &t_Co < 256
 endif
 
 hi clear
-if exists('syntax_on')
-  syntax reset
-endif
+if exists('syntax_on') | syntax reset | endif
+let g:colors_name = 'laserwave256'
 
 hi Normal ctermbg=234 ctermfg=254
 hi ColorColumn cterm=NONE ctermbg=235 ctermfg=NONE


### PR DESCRIPTION
let g:colors_nameを設定しました

```
					*g:colors_name*
	カラースキームが読み込まれているとき (つまり変数 "g:colors_name" が設
	定されているとき) 'background' を変更するとカラースキームが再び読み込
	まれる。カラースキームが 'background' に対応していればこれは適用され
	る。しかしカラースキームが 'background' 自体を設定しているときは効果が
	ない。必要ならば変数 "g:colors_name" を消去すること。
```

また、256colorではないcolorに対して256チェックをするのは厳しいと思ったので、条件分岐を外しました。
